### PR TITLE
Added the logic to save Id and timestamp to Azure Cosmos DB Emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
+# Install curl (if needed for other purposes)
+RUN apt-get update && apt-get install -y curl
+
 # Copy csproj files and restore as distinct layers
 COPY src/service.csproj ./src/
 COPY tests/service-test.csproj ./tests/
@@ -18,6 +21,10 @@ COPY --from=build-env /app/out .
 
 # Expose port 80
 EXPOSE 80
+
+# Set environment variables (if needed)
+ENV CosmosDb__EndpointUri=https://cosmosdb-emulator:8081
+ENV CosmosDb__PrimaryKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
 
 # Set the entry point for the application
 ENTRYPOINT ["dotnet", "service.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 1
       AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
     ports:
-      - "8081:8081" # Endpoint port
-      - "10250:10250" # Direct TCP port
+      - "8081:8081"
+      - "10250:10250"
     volumes:
       - cosmosdbdata:/data
     networks:
       - mynetwork
-
+  
   app:
     build:
       context: .
@@ -23,13 +23,14 @@ services:
     depends_on:
       - cosmosdb-emulator
     environment:
-      - CosmosDb__EndpointUri=https://localhost:8081
-      - CosmosDb__PrimaryKey=C2y6yDjf5/R+ob0N8A7Cgv30VRkkV4RZ0ITF4Zz0A7w=
+      - CosmosDb__EndpointUri=https://cosmosdb-emulator:8081
+      - CosmosDb__PrimaryKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
     networks:
       - mynetwork
 
 networks:
   mynetwork:
+    driver: bridge
 
 volumes:
   cosmosdbdata:

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "CosmosDb": {
+    "EndpointUri": "https://localhost:8081",
+    "PrimaryKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+  }
 }

--- a/src/package/impl.cs
+++ b/src/package/impl.cs
@@ -1,32 +1,98 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Azure.Cosmos;
+using Microsoft.AspNetCore.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Newtonsoft.Json;
 
 namespace PingPong
 {
     public class Program
     {
+        private static readonly string databaseId = "PingPongDb";
+        private static readonly string containerId = "Pings";
+        private static readonly int maxRetries = 5;
+        private static readonly TimeSpan delay = TimeSpan.FromSeconds(5);
+
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
 
-            // Register Cosmos DB service
+            // Hardcoded Cosmos DB configuration
+            string endpointUri = "https://cosmosdb-emulator:8081";
+            string primaryKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+            // Configure HttpClient to ignore SSL certificate validation
+            var httpClientHandler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true
+            };
+
+            var cosmosClientOptions = new CosmosClientOptions
+            {
+                HttpClientFactory = () => new HttpClient(httpClientHandler),
+                ConnectionMode = ConnectionMode.Gateway // Use Gateway mode for HTTP connections
+            };
+
+            // Register Cosmos DB service with retry mechanism
             builder.Services.AddSingleton<CosmosClient>(sp =>
             {
-                var configuration = sp.GetRequiredService<IConfiguration>();
-                var endpointUri = configuration["CosmosDb__EndpointUri"];
-                var primaryKey = configuration["CosmosDb__PrimaryKey"];
-                return new CosmosClient(endpointUri, primaryKey);
+                for (int attempt = 0; attempt < maxRetries; attempt++)
+                {
+                    try
+                    {
+                        Console.WriteLine($"Attempt {attempt + 1} to connect to Cosmos DB Emulator...");
+                        return new CosmosClient(endpointUri, primaryKey, cosmosClientOptions);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Failed to connect to Cosmos DB Emulator: {ex.Message}");
+                        if (attempt == maxRetries - 1)
+                        {
+                            throw;
+                        }
+                        Task.Delay(delay).Wait();
+                    }
+                }
+                throw new Exception("Could not connect to Cosmos DB Emulator after multiple attempts.");
             });
 
             var app = builder.Build();
 
-            app.MapPost("/ping", () => Results.Ok("pong"));
+            app.MapPost("/ping", async (HttpContext context, CosmosClient cosmosClient) =>
+            {
+                var userId = Guid.NewGuid().ToString();
+                var timestamp = DateTime.UtcNow;
+
+                var database = await cosmosClient.CreateDatabaseIfNotExistsAsync(databaseId);
+                var container = await database.Database.CreateContainerIfNotExistsAsync(containerId, "/id");
+
+                // Ensure the id property is set
+                var pingRecord = new PingRecord
+                {
+                    Id = userId,
+                    Timestamp = timestamp
+                };
+
+                await container.Container.CreateItemAsync(pingRecord, new PartitionKey(pingRecord.Id));
+
+                return Results.Ok(new { message = "pong", userId, timestamp });
+            });
 
             app.Run();
         }
+    }
+
+    public class PingRecord
+    {
+        [JsonProperty("id")] // Add this to ensure the property is serialized correctly
+        public string Id { get; set; }
+        public DateTime Timestamp { get; set; }
     }
 }


### PR DESCRIPTION
This changes , create the DB and container if not already existing. Create an ID and a timestamp of the last /ping request and insure that the PingRecord Object is Serialize so the Id is properly named id to meet the Azure Cosmos expectation.